### PR TITLE
Updated hanlding of dropdown click events

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -17,13 +17,17 @@ export default defineConfig([
             {
                 file: packageJson.main,
                 format: 'cjs',
-                sourcemap: true,
+                sourcemap: true
             },
             {
                 file: packageJson.module,
                 format: 'esm',
-                sourcemap: true,
+                sourcemap: true
             },
+        ],
+        external: [
+            'react',
+            'react-dom'
         ],
         plugins: [
             resolve(),

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -78,7 +78,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({ children, ...props }) => {
 
     return (
         <DropdownContext.Provider value={value}>
-            <div {...props}>{children}</div>
+            <div className='dropdown-menu' {...props}>{children}</div>
         </DropdownContext.Provider>
     );
 };

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import React, { createContext, useState, useCallback } from 'react';
+import React, { createContext, useState, useCallback, useRef } from 'react';
 
 /**
  * DropdownContext
@@ -22,11 +22,13 @@ import React, { createContext, useState, useCallback } from 'react';
  * @property {boolean} isOpen - Indicates whether the dropdown is currently open.
  * @property {() => void} toggleDropdown - Function to toggle the dropdown's visibility.
  * @property {() => void} closeDropdown - Function to close the dropdown.
+ * @property {HTMLElement} triggerRef - A reference to the dropdown menu's trigger component.
  */
 interface DropdownContextType {
     isOpen: boolean;
     toggleDropdown: () => void;
     closeDropdown: () => void;
+    triggerRef: React.RefObject<HTMLElement>;
 };
 
 export const DropdownContext = createContext<DropdownContextType | undefined>(undefined);
@@ -61,6 +63,7 @@ type DropdownMenuProps = React.HTMLAttributes<HTMLDivElement>;
  */
 const DropdownMenu: React.FC<DropdownMenuProps> = ({ children, ...props }) => {
     const [isOpen, setIsOpen] = useState(false);
+    const triggerRef = useRef<HTMLElement>(null);
 
     const toggleDropdown = useCallback(() => {
         setIsOpen((prev) => !prev);
@@ -74,6 +77,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({ children, ...props }) => {
         isOpen,
         toggleDropdown,
         closeDropdown,
+        triggerRef,
     };
 
     return (

--- a/src/components/DropdownMenu/DropdownMenuContent.tsx
+++ b/src/components/DropdownMenu/DropdownMenuContent.tsx
@@ -38,12 +38,19 @@ const DropdownMenuContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ c
 
     const { isOpen, closeDropdown } = context;
     const contentRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLElement | null>(null);
 
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
-            if (contentRef.current && !contentRef.current.contains(event.target as Node)) {
-                closeDropdown();
+            if (contentRef.current && contentRef.current.contains(event.target as Node)) {
+                return;
             }
+
+            if (triggerRef.current && triggerRef.current.contains(event.target as Node)) {
+                return;
+            }
+
+            closeDropdown();
         };
 
         if (isOpen) {
@@ -60,7 +67,7 @@ const DropdownMenuContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ c
     }
 
     return (
-        <div ref={contentRef} {...props}>
+        <div className='dropdown-menu-content' ref={contentRef} {...props}>
             {children}
         </div>
     );

--- a/src/components/DropdownMenu/DropdownMenuContent.tsx
+++ b/src/components/DropdownMenu/DropdownMenuContent.tsx
@@ -36,17 +36,14 @@ const DropdownMenuContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ c
         throw new Error('DropdownMenuContent must be used within a DropdownMenu');
     }
 
-    const { isOpen, closeDropdown } = context;
+    const { isOpen, closeDropdown, triggerRef } = context;
     const contentRef = useRef<HTMLDivElement>(null);
-    const triggerRef = useRef<HTMLElement | null>(null);
 
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
-            if (contentRef.current && contentRef.current.contains(event.target as Node)) {
-                return;
-            }
+            const target = event.target as Node;
 
-            if (triggerRef.current && triggerRef.current.contains(event.target as Node)) {
+            if (contentRef.current?.contains(target) || triggerRef.current?.contains(target)) {
                 return;
             }
 

--- a/src/components/DropdownMenu/DropdownTrigger.tsx
+++ b/src/components/DropdownMenu/DropdownTrigger.tsx
@@ -45,17 +45,29 @@ const DropdownTrigger: React.FC<DropdownTriggerProps> = ({ children, asChild = f
         throw new Error('DropdownTrigger must be used within a DropdownMenu');
     }
 
-    const { toggleDropdown } = context;
+    const { isOpen, toggleDropdown, closeDropdown } = context;
+
+    const handleClick = (event: React.MouseEvent) => {
+        event.preventDefault();
+        
+        if (isOpen) {
+            closeDropdown();
+            console.log('Attempted to close.');
+        } else {
+            toggleDropdown();
+            console.log('Toggled instead');
+        }
+    };
 
     if (asChild && React.isValidElement(children)) {
         return cloneElement(children as ReactElement, {
-            onClick: toggleDropdown,
+            onClick: handleClick,
             ...props,
         });
     }
 
     return (
-        <div onClick={toggleDropdown} {...props}>
+        <div className='dropdown-menu-trigger' onClick={handleClick} {...props}>
             {children}
         </div>
     );

--- a/src/components/DropdownMenu/DropdownTrigger.tsx
+++ b/src/components/DropdownMenu/DropdownTrigger.tsx
@@ -45,29 +45,29 @@ const DropdownTrigger: React.FC<DropdownTriggerProps> = ({ children, asChild = f
         throw new Error('DropdownTrigger must be used within a DropdownMenu');
     }
 
-    const { isOpen, toggleDropdown, closeDropdown } = context;
+    const { isOpen, toggleDropdown, closeDropdown, triggerRef } = context;
 
     const handleClick = (event: React.MouseEvent) => {
         event.preventDefault();
         
         if (isOpen) {
             closeDropdown();
-            console.log('Attempted to close.');
         } else {
             toggleDropdown();
-            console.log('Toggled instead');
         }
     };
 
     if (asChild && React.isValidElement(children)) {
         return cloneElement(children as ReactElement, {
+            ref: triggerRef,
             onClick: handleClick,
             ...props,
         });
     }
 
     return (
-        <div className='dropdown-menu-trigger' onClick={handleClick} {...props}>
+        <div className='dropdown-menu-trigger' onClick={handleClick} 
+              ref={triggerRef as React.RefObject<HTMLDivElement>} {...props}>
             {children}
         </div>
     );


### PR DESCRIPTION
The dropdown menu trigger will now properly close the dropdown menu content if a click is handled either outside of the content element or if the trigger itself it clicked again